### PR TITLE
include the decrunch name in setup() call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,4 +22,4 @@ if cythonize:
 	extensions = cythonize(extensions)
 
 
-setup(ext_modules=extensions)
+setup(ext_modules=extensions, name="decrunch")


### PR DESCRIPTION
I was seeing decrunch installed to folders with UNKNOWN in their name.