### PR TITLE
Fix Mac OS Build

### DIFF
--- a/crunch/crn_decomp.h
+++ b/crunch/crn_decomp.h
@@ -341,6 +341,8 @@ const unsigned int cCRNHeaderMinSize = 62U;
 #include <stdlib.h>
 #ifdef WIN32
 #include <memory.h>
+#elif defined __APPLE__
+#include <malloc/malloc.h>
 #else
 #include <malloc.h>
 #endif


### PR DESCRIPTION
Fixed 'missing <malloc.h>' on Mac OS by the modification below.