### PR TITLE
Mac Compatibility & Github Workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,57 @@
+name: Test and Publish
+
+on: [push, pull_request]
+
+jobs:
+  deploy:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [
+          "ubuntu-latest",
+          "macOS-latest",
+          "windows-latest"
+        ]
+        python-version: [
+          "3.8",
+          "3.7",
+          "3.6",
+        ]
+        architecture: ["x86", "x64"]
+    
+    timeout-minutes: 30
+
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }} ${{ matrix.architecture }} - ${{ matrix.python-version }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade pip wheel setuptools twine
+        pip install Cython pytest pillow
+    
+    - name: Install module
+      run: |
+        python setup.py install
+    
+    - name: Test with pytest
+      run: |
+        pytest -v -s
+      
+    # - name: Build and publish
+    #   if: success() && runner.os != 'Linux' && github.event_name == 'push'
+    #   env:
+    #     TWINE_USERNAME: __token__
+    #     TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+    #   run: |
+    #     python setup.py sdist bdist_wheel
+    #     twine upload dist/* --skip-existing

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,24 @@
-# https://travis-ci.org/HearthSim/decrunch
-dist: xenial
-language: python
-
-python:
-  - 3.5
-  - 3.6
-  - 3.7
-
-cache: pip
-
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-8
-
-env:
-  - CXX=g++-8
+language: python            # this works for Linux but is an error on macOS or Windows
+jobs:
+  include:
+    - name: "Python 3.8.0 on Xenial Linux"
+      python: 3.8           # this works for Linux but is ignored on macOS or Windows
+    - name: "Python 3.7.4 on macOS"
+      os: osx
+      osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
+      language: shell       # 'language: python' is an error on Travis CI macOS
+    - name: "Python 3.8.0 on Windows"
+      os: windows           # Windows 10.0.17134 N/A Build 17134
+      language: shell       # 'language: python' is an error on Travis CI Windows
+      before_install:
+        - choco install python --version 3.8.0
+        - python -m pip install --upgrade pip
+      env: PATH=/c/Python38:/c/Python38/Scripts:$PATH
 
 install:
-  - pip install --upgrade pip wheel setuptools
-  - pip install Cython
-  - pip install .
+  - pip3 install --upgrade pip wheel setuptools
+  - pip3 install Cython pytest pillow
+  - pip3 install .
 
 script:
   - pytest -v

--- a/crn_decomp.cpp
+++ b/crn_decomp.cpp
@@ -4,6 +4,7 @@
 
 #if defined(__APPLE__)
 #define malloc_usable_size malloc_size
+#include <malloc/malloc.h>
 #else
 #if defined(__FreeBSD__)
 #include <stdlib.h>

--- a/crunch/crn_decomp.h
+++ b/crunch/crn_decomp.h
@@ -341,8 +341,6 @@ const unsigned int cCRNHeaderMinSize = 62U;
 #include <stdlib.h>
 #ifdef WIN32
 #include <memory.h>
-#else
-#include <malloc.h>
 #endif
 #include <new> // needed for placement new, _msize, _expand
 #include <stdarg.h>


### PR DESCRIPTION
This PR makes decrunch compatible with Mac and adds tests for Linux, Mac, and Windows on travis and Github Actions.

The commented section at the end of .github/workflows/python-package.yml can be used to upload wheels for Mac and Windows to pypi.

`     - name: Build and publish
       if: success() && runner.os != 'Linux' && github.event_name == 'push'
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/* --skip-existing
`

secrets.PYPI_TOKEN has to be set in the settings of the github project.