### PR TITLE
make sure macos build works

### DIFF
--- a/crunch/crn_decomp.h
+++ b/crunch/crn_decomp.h
@@ -403,7 +403,11 @@ typedef uint64 ptr_bits;
 #ifdef __x86_64__
 typedef uint64 ptr_bits;
 #else
+#ifdef __APPLE__
+typedef uint64 ptr_bits;
+#else
 typedef uint32 ptr_bits;
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
- after catalina, macos drop 32bit support
- there are no mac check to make sure ptr_bits are 64bit
  but only windows and linux check

```
crunch/crn_decomp.h:2353:15: error: cast from pointer to smaller type 'crnd::ptr_bits' (aka 'unsigned int') loses
      information
        if ((uint32) reinterpret_cast<ptr_bits>(p) & (CRND_MIN_ALLOC_ALIGNMENT - 1)) {
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
crunch/crn_decomp.h:2378:15: error: cast from pointer to smaller type 'crnd::ptr_bits' (aka 'unsigned int') loses
      information
        if ((uint32) reinterpret_cast<ptr_bits>(p) & (CRND_MIN_ALLOC_ALIGNMENT - 1)) {
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
crunch/crn_decomp.h:2390:15: error: cast from pointer to smaller type 'crnd::ptr_bits' (aka 'unsigned int') loses
      information
        if ((uint32) reinterpret_cast<ptr_bits>(p) & (CRND_MIN_ALLOC_ALIGNMENT - 1)) {
```